### PR TITLE
Add impl for num::Bounded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ description = "Reversed ordering crate for rust"
 repository = "https://github.com/brandonson/revord-rs"
 license = "MIT"
 readme = "README.md"
+
+[dependencies]
+num = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,10 @@
  *
  */
 
+extern crate num;
+
 use std::cmp::Ordering;
+use num::Bounded;
 
 ///Type that should be ordered in
 ///the reverse order of any value it contains.
@@ -53,9 +56,19 @@ impl<V> Ord for RevOrd<V> where V: Ord {
     }
 }
 
+impl<V: Bounded> Bounded for RevOrd<V> {
+    fn min_value() -> RevOrd<V> {
+        RevOrd(V::max_value())
+    }
+    
+    fn max_value() -> RevOrd<V> {
+        RevOrd(V::min_value())
+    }
+}
+
 #[cfg(test)]
 mod test {
-
+  use super::num::Bounded;
   use super::RevOrd;
 
   #[test]
@@ -63,4 +76,12 @@ mod test {
     assert!(RevOrd(1) > RevOrd(2));
     assert!(RevOrd(1) < RevOrd(0));
   }
+
+    #[test]
+    fn int_bounds_test() {
+        let max: RevOrd<i32> = Bounded::max_value();
+        let min: RevOrd<i32> = Bounded::min_value();
+        
+        assert!(max > min);
+    }
 }


### PR DESCRIPTION
This adds an impl for `num::Bounded` for `RevOrd`. It's reversed, so that `min_value() < max_value()` still holds.
